### PR TITLE
add missing html tag "</p>" / clean-up template to get smaller and cleaner output

### DIFF
--- a/templates/default_html.template
+++ b/templates/default_html.template
@@ -22,82 +22,82 @@ See "get_license_file_key" in `attrib.py` for more information
 #}
 <!doctype html>
 <html>
-	<head>
-		<style type="text/css">
-			div.additional-license-text-list {display:block}
-			body {font-family: Helvetica, Arial, sans-serif;}
-			pre {white-space: pre-wrap;}
-		</style>
-		<title>Open Source Software Information</title>
-	</head>
-	<body>
-		<h1>OPEN SOURCE SOFTWARE INFORMATION</h1>
-		<div> <p>Licenses, acknowledgments and required copyright notices for open source components:</p> </div>
-		<div class="oss-table-of-contents">
+  <head>
+    <style type="text/css">
+      div.additional-license-text-list {display:block}
+      body {font-family: Helvetica, Arial, sans-serif;}
+      pre {white-space: pre-wrap;}
+    </style>
+    <title>Open Source Software Information</title>
+  </head>
+  <body>
+    <h1>OPEN SOURCE SOFTWARE INFORMATION</h1>
+    <div> <p>Licenses, acknowledgments and required copyright notices for open source components:</p> </div>
+    <div class="oss-table-of-contents">
 {% for about_object in abouts %}
-			<p><a href="#component_{{ loop.index0 }}">{{ about_object.name.value }}{% if about_object.version.value %} {{ about_object.version.value }}{% endif %}</a></p>
+      <p><a href="#component_{{ loop.index0 }}">{{ about_object.name.value }}{% if about_object.version.value %} {{ about_object.version.value }}{% endif %}</a></p>
 {% endfor %}
-		</div>
-	<hr/>
+    </div>
+  <hr/>
 {% for about_object in abouts %}
-	<div class="oss-component" id="component_{{ loop.index0 }}">
-		<h3 class="component-name">{{ about_object.name.value }} {% if about_object.version.value %}{{ about_object.version.value }}{% endif %} </h3>
-{% 	if about_object.license_expression.value %}
-		<p>This component is licensed under {{ about_object.license_expression.value }}</p>
-{% 	endif %}
-{% 	if about_object.copyright.value %}
-		<pre>
+  <div class="oss-component" id="component_{{ loop.index0 }}">
+    <h3 class="component-name">{{ about_object.name.value }} {% if about_object.version.value %}{{ about_object.version.value }}{% endif %} </h3>
+{%   if about_object.license_expression.value %}
+    <p>This component is licensed under {{ about_object.license_expression.value }}</p>
+{%   endif %}
+{%   if about_object.copyright.value %}
+    <pre>
 {{about_object.copyright.value}}
-		</pre>
-{% 	endif %}
-{% 	if about_object.notice_file.value %}
-{%		for notice in about_object.notice_file.value %}
-		<pre class="component-notice">
+    </pre>
+{%   endif %}
+{%   if about_object.notice_file.value %}
+{%    for notice in about_object.notice_file.value %}
+    <pre class="component-notice">
 {{ about_object.notice_file.value[notice] }}
-		</pre>
-{%		endfor %}
-{% 	endif %}
-{% 	if about_object.license_key.value %}
-{% 		for license_key in about_object.license_key.value %}
-{% 			if license_key in common_licenses %}
-		<p>Full text of <a class="{{ license_key }}" href="#component-license-{{ license_key }}"> {{ license_key }}</a> is available at the end of this document.</p>
-{% 			endif %}
-{% 		endfor %}
-{% 		if about_object.license_file.value %}
-{% 			for lic_file_name in about_object.license_file.value %}
-{% 				if not license_file_key_and_license_key[license_file_name_and_license_file_key[lic_file_name]] in common_licenses %}
-{% 					if about_object.license_file.value[lic_file_name] %}
-		<pre>
+    </pre>
+{%    endfor %}
+{%   endif %}
+{%   if about_object.license_key.value %}
+{%     for license_key in about_object.license_key.value %}
+{%       if license_key in common_licenses %}
+    <p>Full text of <a class="{{ license_key }}" href="#component-license-{{ license_key }}"> {{ license_key }}</a> is available at the end of this document.</p>
+{%       endif %}
+{%     endfor %}
+{%     if about_object.license_file.value %}
+{%       for lic_file_name in about_object.license_file.value %}
+{%         if not license_file_key_and_license_key[license_file_name_and_license_file_key[lic_file_name]] in common_licenses %}
+{%           if about_object.license_file.value[lic_file_name] %}
+    <pre>
 {{ about_object.license_file.value[lic_file_name] | e}}
-		</pre>
-{% 					endif %}
-{% 				endif %}
-{% 			endfor %}
-{% 		endif %}
-{% 	else %}
-{% 		if about_object.license_file.value %}
-{% 			for lic_file_name in about_object.license_file.value %}
-{% 				if about_object.license_file.value[lic_file_name] %}
-		<pre>
+    </pre>
+{%           endif %}
+{%         endif %}
+{%       endfor %}
+{%     endif %}
+{%   else %}
+{%     if about_object.license_file.value %}
+{%       for lic_file_name in about_object.license_file.value %}
+{%         if about_object.license_file.value[lic_file_name] %}
+    <pre>
 {{ about_object.license_file.value[lic_file_name] | e}}
-		</pre>
-{% 				endif %}
-{% 			endfor %}
-{% 		endif %}
-{% 	endif %}
-	</div>
+    </pre>
+{%         endif %}
+{%       endfor %}
+{%     endif %}
+{%   endif %}
+  </div>
 {% endfor %}
-	<hr/>
-	<h3>Common Licenses Used in This Product</h3>
+  <hr/>
+  <h3>Common Licenses Used in This Product</h3>
 {% for key in license_file_key_and_context %}
-{% 	if key in common_licenses %}
-	<h3 id="component-license-{{ key }}">{{ key }}</h3>
-	<pre>
+{%   if key in common_licenses %}
+  <h3 id="component-license-{{ key }}">{{ key }}</h3>
+  <pre>
 {{ license_file_key_and_context[key]|e }}
-	</pre>
-{% 	endif %}
+  </pre>
+{%   endif %}
 {% endfor %}
-	<h3><a id="End">End</a></h3>
-	<i>This file was generated with AboutCode Toolkit version: {{ tkversion }} on: {{ utcnow }} (UTC)</i>
-	</body>
+  <h3><a id="End">End</a></h3>
+  <i>This file was generated with AboutCode Toolkit version: {{ tkversion }} on: {{ utcnow }} (UTC)</i>
+  </body>
 </html>

--- a/templates/default_html.template
+++ b/templates/default_html.template
@@ -22,92 +22,72 @@ See "get_license_file_key" in `attrib.py` for more information
 #}
 <!doctype html>
 <html>
-  <head>
-    <style type="text/css">
-      div.additional-license-text-list {display:block}
-      body {font-family: Helvetica, Arial, sans-serif;}
-      pre {white-space: pre-wrap;}
-    </style>
-    <title>Open Source Software Information</title>
-  </head>
-
-  <body>
-    <h1>OPEN SOURCE SOFTWARE INFORMATION</h1>
-    <div>
-      <p>Licenses, acknowledgments and required copyright notices for 
-      open source components:</p>
-    </div>
-    
-        <div class="oss-table-of-contents">
-            {% for about_object in abouts %}
-                <p><a href="#component_{{ loop.index0 }}">{{ about_object.name.value }}{% if about_object.version.value %} {{ about_object.version.value }}{% endif %}</a></p>
-            {% endfor %}
-        </div>
-
-    <hr/>
-
-
-    {% for about_object in abouts %}
-        <div class="oss-component" id="component_{{ loop.index0 }}">
-            <h3 class="component-name">{{ about_object.name.value }}
-                {% if about_object.version.value %}{{ about_object.version.value }}{% endif %}
-            </h3>
-            {% if about_object.license_expression.value %}
-                <p>This component is licensed under 
-                {{ about_object.license_expression.value }}
-            {% endif %}
-            {% if about_object.copyright.value %}
-                <pre>{{about_object.copyright.value}}</pre>
-            {% endif %}
-            {% if about_object.notice_file.value %}
-                {% for notice in about_object.notice_file.value %}
-                    <pre class="component-notice">{{ about_object.notice_file.value[notice] }}</pre>
-                {% endfor %}
-            {% endif %}
-            {% if about_object.license_key.value %}
-                {% for license_key in about_object.license_key.value %}
-                    {% if license_key in common_licenses %}
-                        <p>Full text of
-                            <a class="{{ license_key }}" href="#component-license-{{ license_key }}">
-                            {{ license_key }}
-                            </a>
-                            is available at the end of this document.</p>
-                    {% endif %}
-                 {% endfor %}
-                {% if about_object.license_file.value %}
-                    {% for lic_file_name in about_object.license_file.value %}
-                        {% if not license_file_key_and_license_key[license_file_name_and_license_file_key[lic_file_name]] in common_licenses %}
-                            {% if about_object.license_file.value[lic_file_name] %}
-                                <pre>{{ about_object.license_file.value[lic_file_name] | e}}</pre>
-                            {% endif %}
-                        {% endif %}
-                    {% endfor %}
-                {% endif %}
-            {% else %}
-                {% if about_object.license_file.value %}
-                    {% for lic_file_name in about_object.license_file.value %}
-                        {% if about_object.license_file.value[lic_file_name] %}
-                            <pre>{{ about_object.license_file.value[lic_file_name] | e}}</pre>
-                        {% endif %}
-                    {% endfor %}
-                {% endif %}
-            {% endif %}
-        </div>
-    {% endfor %}
-
-    <hr/>
-
-    <h3>Common Licenses Used in This Product</h3>
-
-    {% for key in license_file_key_and_context %}
-        {% if key in common_licenses %}
-            <h3 id="component-license-{{ key }}">{{ key }}</h3>
-            <pre>{{ license_file_key_and_context[key]|e }}</pre>
-        {% endif %}
-    {% endfor %}
-
-    <h3><a id="End">End</a></h3>
-    <i>This file was generated with AboutCode Toolkit version: {{ tkversion }} on: {{ utcnow }} (UTC)</i>
-    </body>
+	<head>
+		<style type="text/css">
+			div.additional-license-text-list {display:block}
+			body {font-family: Helvetica, Arial, sans-serif;}
+			pre {white-space: pre-wrap;}
+		</style>
+		<title>Open Source Software Information</title>
+	</head>
+	<body>
+		<h1>OPEN SOURCE SOFTWARE INFORMATION</h1>
+		<div> <p>Licenses, acknowledgments and required copyright notices for open source components:</p> </div>
+		<div class="oss-table-of-contents">
+{% for about_object in abouts %}
+			<p><a href="#component_{{ loop.index0 }}">{{ about_object.name.value }}{% if about_object.version.value %} {{ about_object.version.value }}{% endif %}</a></p>
+{% endfor %}
+		</div>
+	<hr/>
+{% for about_object in abouts %}
+	<div class="oss-component" id="component_{{ loop.index0 }}">
+	<h3 class="component-name">{{ about_object.name.value }} {% if about_object.version.value %}{{ about_object.version.value }}{% endif %} </h3>
+{% 	if about_object.license_expression.value %}
+	<p>This component is licensed under {{ about_object.license_expression.value }}</p>
+{% 	endif %}
+{% 	if about_object.copyright.value %}
+	<pre>{{about_object.copyright.value}}</pre>
+{% 	endif %}
+{% 	if about_object.notice_file.value %}
+{%		for notice in about_object.notice_file.value %}
+	<pre class="component-notice">{{ about_object.notice_file.value[notice] }}</pre>
+{%		endfor %}
+{% 	endif %}
+{% 	if about_object.license_key.value %}
+{% 		for license_key in about_object.license_key.value %}
+{% 			if license_key in common_licenses %}
+	<p>Full text of <a class="{{ license_key }}" href="#component-license-{{ license_key }}"> {{ license_key }}</a> is available at the end of this document.</p>
+{% 			endif %}
+{% 		endfor %}
+{% 		if about_object.license_file.value %}
+{% 			for lic_file_name in about_object.license_file.value %}
+{% 				if not license_file_key_and_license_key[license_file_name_and_license_file_key[lic_file_name]] in common_licenses %}
+{% 					if about_object.license_file.value[lic_file_name] %}
+	<pre>{{ about_object.license_file.value[lic_file_name] | e}}</pre>
+{% 					endif %}
+{% 				endif %}
+{% 			endfor %}
+{% 		endif %}
+{% 	else %}
+{% 		if about_object.license_file.value %}
+{% 			for lic_file_name in about_object.license_file.value %}
+{% 				if about_object.license_file.value[lic_file_name] %}
+	<pre>{{ about_object.license_file.value[lic_file_name] | e}}</pre>
+{% 				endif %}
+{% 			endfor %}
+{% 		endif %}
+{% 	endif %}
+	</div>
+{% endfor %}
+	<hr/>
+	<h3>Common Licenses Used in This Product</h3>
+{% for key in license_file_key_and_context %}
+{% 	if key in common_licenses %}
+	<h3 id="component-license-{{ key }}">{{ key }}</h3>
+	<pre>{{ license_file_key_and_context[key]|e }}</pre>
+{% 	endif %}
+{% endfor %}
+	<h3><a id="End">End</a></h3>
+	<i>This file was generated with AboutCode Toolkit version: {{ tkversion }} on: {{ utcnow }} (UTC)</i>
+	</body>
 </html>
-

--- a/templates/default_html.template
+++ b/templates/default_html.template
@@ -41,29 +41,35 @@ See "get_license_file_key" in `attrib.py` for more information
 	<hr/>
 {% for about_object in abouts %}
 	<div class="oss-component" id="component_{{ loop.index0 }}">
-	<h3 class="component-name">{{ about_object.name.value }} {% if about_object.version.value %}{{ about_object.version.value }}{% endif %} </h3>
+		<h3 class="component-name">{{ about_object.name.value }} {% if about_object.version.value %}{{ about_object.version.value }}{% endif %} </h3>
 {% 	if about_object.license_expression.value %}
-	<p>This component is licensed under {{ about_object.license_expression.value }}</p>
+		<p>This component is licensed under {{ about_object.license_expression.value }}</p>
 {% 	endif %}
 {% 	if about_object.copyright.value %}
-	<pre>{{about_object.copyright.value}}</pre>
+		<pre>
+{{about_object.copyright.value}}
+		</pre>
 {% 	endif %}
 {% 	if about_object.notice_file.value %}
 {%		for notice in about_object.notice_file.value %}
-	<pre class="component-notice">{{ about_object.notice_file.value[notice] }}</pre>
+		<pre class="component-notice">
+{{ about_object.notice_file.value[notice] }}
+		</pre>
 {%		endfor %}
 {% 	endif %}
 {% 	if about_object.license_key.value %}
 {% 		for license_key in about_object.license_key.value %}
 {% 			if license_key in common_licenses %}
-	<p>Full text of <a class="{{ license_key }}" href="#component-license-{{ license_key }}"> {{ license_key }}</a> is available at the end of this document.</p>
+		<p>Full text of <a class="{{ license_key }}" href="#component-license-{{ license_key }}"> {{ license_key }}</a> is available at the end of this document.</p>
 {% 			endif %}
 {% 		endfor %}
 {% 		if about_object.license_file.value %}
 {% 			for lic_file_name in about_object.license_file.value %}
 {% 				if not license_file_key_and_license_key[license_file_name_and_license_file_key[lic_file_name]] in common_licenses %}
 {% 					if about_object.license_file.value[lic_file_name] %}
-	<pre>{{ about_object.license_file.value[lic_file_name] | e}}</pre>
+		<pre>
+{{ about_object.license_file.value[lic_file_name] | e}}
+		</pre>
 {% 					endif %}
 {% 				endif %}
 {% 			endfor %}
@@ -72,7 +78,9 @@ See "get_license_file_key" in `attrib.py` for more information
 {% 		if about_object.license_file.value %}
 {% 			for lic_file_name in about_object.license_file.value %}
 {% 				if about_object.license_file.value[lic_file_name] %}
-	<pre>{{ about_object.license_file.value[lic_file_name] | e}}</pre>
+		<pre>
+{{ about_object.license_file.value[lic_file_name] | e}}
+		</pre>
 {% 				endif %}
 {% 			endfor %}
 {% 		endif %}
@@ -84,7 +92,9 @@ See "get_license_file_key" in `attrib.py` for more information
 {% for key in license_file_key_and_context %}
 {% 	if key in common_licenses %}
 	<h3 id="component-license-{{ key }}">{{ key }}</h3>
-	<pre>{{ license_file_key_and_context[key]|e }}</pre>
+	<pre>
+{{ license_file_key_and_context[key]|e }}
+	</pre>
 {% 	endif %}
 {% endfor %}
 	<h3><a id="End">End</a></h3>

--- a/tests/testdata/test_attrib/gen_default_template/expected_default_attrib.html
+++ b/tests/testdata/test_attrib/gen_default_template/expected_default_attrib.html
@@ -1,51 +1,38 @@
 
 <!doctype html>
 <html>
-  <head>
-    <style type="text/css">
-      div.additional-license-text-list {display:block}
-      body {font-family: Helvetica, Arial, sans-serif;}
-      pre {white-space: pre-wrap;}
-    </style>
-    <title>Open Source Software Information</title>
-  </head>
+	<head>
+		<style type="text/css">
+			div.additional-license-text-list {display:block}
+			body {font-family: Helvetica, Arial, sans-serif;}
+			pre {white-space: pre-wrap;}
+		</style>
+		<title>Open Source Software Information</title>
+	</head>
+	<body>
+		<h1>OPEN SOURCE SOFTWARE INFORMATION</h1>
+		<div> <p>Licenses, acknowledgments and required copyright notices for open source components:</p> </div>
+		<div class="oss-table-of-contents">
 
-  <body>
-    <h1>OPEN SOURCE SOFTWARE INFORMATION</h1>
-    <div>
-      <p>Licenses, acknowledgments and required copyright notices for 
-      open source components:</p>
-    </div>
-    
-        <div class="oss-table-of-contents">
-            
-                <p><a href="#component_0">Apache HTTP Server 2.4.3</a></p>
-            
-        </div>
+			<p><a href="#component_0">Apache HTTP Server 2.4.3</a></p>
 
-    <hr/>
+		</div>
+	<hr/>
+
+	<div class="oss-component" id="component_0">
+	<h3 class="component-name">Apache HTTP Server 2.4.3 </h3>
 
 
-    
-        <div class="oss-component" id="component_0">
-            <h3 class="component-name">Apache HTTP Server
-                2.4.3
-            </h3>
-            
-            
-            
-            
-                
-            
-        </div>
-    
 
-    <hr/>
 
-    <h3>Common Licenses Used in This Product</h3>
 
-    
 
-    <h3><a id="End">End</a></h3>
-    </body>
+	</div>
+
+	<hr/>
+	<h3>Common Licenses Used in This Product</h3>
+
+	<h3><a id="End">End</a></h3>
+	<i>This file was generated with AboutCode Toolkit version: 6.0.0 on: 2021-08-26 14:20:37.852657 (UTC)</i>
+	</body>
 </html>

--- a/tests/testdata/test_attrib/gen_default_template/expected_default_attrib.html
+++ b/tests/testdata/test_attrib/gen_default_template/expected_default_attrib.html
@@ -1,38 +1,38 @@
 
 <!doctype html>
 <html>
-	<head>
-		<style type="text/css">
-			div.additional-license-text-list {display:block}
-			body {font-family: Helvetica, Arial, sans-serif;}
-			pre {white-space: pre-wrap;}
-		</style>
-		<title>Open Source Software Information</title>
-	</head>
-	<body>
-		<h1>OPEN SOURCE SOFTWARE INFORMATION</h1>
-		<div> <p>Licenses, acknowledgments and required copyright notices for open source components:</p> </div>
-		<div class="oss-table-of-contents">
+  <head>
+    <style type="text/css">
+      div.additional-license-text-list {display:block}
+      body {font-family: Helvetica, Arial, sans-serif;}
+      pre {white-space: pre-wrap;}
+    </style>
+    <title>Open Source Software Information</title>
+  </head>
+  <body>
+    <h1>OPEN SOURCE SOFTWARE INFORMATION</h1>
+    <div> <p>Licenses, acknowledgments and required copyright notices for open source components:</p> </div>
+    <div class="oss-table-of-contents">
 
-			<p><a href="#component_0">Apache HTTP Server 2.4.3</a></p>
+      <p><a href="#component_0">Apache HTTP Server 2.4.3</a></p>
 
-		</div>
-	<hr/>
+    </div>
+  <hr/>
 
-	<div class="oss-component" id="component_0">
-		<h3 class="component-name">Apache HTTP Server 2.4.3 </h3>
-
-
+  <div class="oss-component" id="component_0">
+    <h3 class="component-name">Apache HTTP Server 2.4.3 </h3>
 
 
 
 
-	</div>
 
-	<hr/>
-	<h3>Common Licenses Used in This Product</h3>
 
-	<h3><a id="End">End</a></h3>
-	<i>This file was generated with AboutCode Toolkit version: 6.0.0 on: 2021-08-26 14:42:50.530382 (UTC)</i>
-	</body>
+  </div>
+
+  <hr/>
+  <h3>Common Licenses Used in This Product</h3>
+
+  <h3><a id="End">End</a></h3>
+  <i>This file was generated with AboutCode Toolkit version: 6.0.0 on: 2021-08-30 10:58:38.548879 (UTC)</i>
+  </body>
 </html>

--- a/tests/testdata/test_attrib/gen_default_template/expected_default_attrib.html
+++ b/tests/testdata/test_attrib/gen_default_template/expected_default_attrib.html
@@ -20,7 +20,7 @@
 	<hr/>
 
 	<div class="oss-component" id="component_0">
-	<h3 class="component-name">Apache HTTP Server 2.4.3 </h3>
+		<h3 class="component-name">Apache HTTP Server 2.4.3 </h3>
 
 
 
@@ -33,6 +33,6 @@
 	<h3>Common Licenses Used in This Product</h3>
 
 	<h3><a id="End">End</a></h3>
-	<i>This file was generated with AboutCode Toolkit version: 6.0.0 on: 2021-08-26 14:20:37.852657 (UTC)</i>
+	<i>This file was generated with AboutCode Toolkit version: 6.0.0 on: 2021-08-26 14:42:50.530382 (UTC)</i>
 	</body>
 </html>


### PR DESCRIPTION
-  add missing html tag `</p>`
`<p>This component is licensed under {{ about_object.license_expression.value }}</p>`
- replace spaces for indentation with tabs and move indentation of dyn-html commands into the commands itself to.
  This reduces the size of the output html and makes generated output much cleaner. (needed for embedded devices with
  small storage)

Signed-off-by: Stephan Enderlein <stephan@freifunk-dresden.de>