### PR TITLE
Changed python version requirement from version 3 to version 3.6.2 or above 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Build and tests status
 
 REQUIREMENTS
 ------------
-The AboutCode Toolkit is tested with Python 3 only on Linux, Mac and Windows.
+The AboutCode Toolkit is tested with Python 3.6.2 or above only on Linux, Mac and Windows.
 You will need to install a Python interpreter if you do not have one already
 installed.
 


### PR DESCRIPTION
fix #466  
I was using python 3.6.0 and have the following error AttributeError: module 'typing' has no attribute 'NoReturn' when running tests related to Jinja2
I found a similar problem here: https://stackoverflow.com/questions/67569038/attributeerror-module-typing-has-no-attribute-noreturn/67857937#67857937 which suggests using python 3.6.2 or above.
