### PR TITLE
Updated specification.rst file url in  readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,7 @@ identify redistributable source code used in your project to help you comply
 with open source licenses conditions.
 
 This version of the AboutCode Toolkit follows the ABOUT specification version 3.2.1 at:
-https://github.com/nexB/aboutcode-toolkit/blob/develop/SPECIFICATION.rst
-
+https://github.com/nexB/aboutcode-toolkit/blob/develop/docs/source/specification.rst
 
 Build and tests status
 ----------------------


### PR DESCRIPTION
well it seems that the old URL  - https://github.com/nexB/aboutcode-toolkit/blob/develop/SPECIFICATION.rst 
is pointing to the wrong path and it's kinda dead link so I have replaced the old file path URL with a new file path URL 