### PR TITLE
updated specification.rst file link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,7 @@ identify redistributable source code used in your project to help you comply
 with open source licenses conditions.
 
 This version of the AboutCode Toolkit follows the ABOUT specification version 3.2.1 at:
-https://github.com/nexB/aboutcode-toolkit/blob/develop/SPECIFICATION.rst
-
+https://github.com/nexB/aboutcode-toolkit/blob/develop/docs/source/specification.rst
 
 Build and tests status
 ----------------------


### PR DESCRIPTION
well it seems that the specification.rst file path has been updated but in the readme doc there is still an old file path and it is kinda deadline
https://github.com/nexB/aboutcode-toolkit/blob/develop/SPECIFICATION.rst
so I have updated the old URL path with the new one and now it is redirecting to the correct page