### PR TITLE
Use star-free new syntax for python requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ zip_safe = false
 
 setup_requires = setuptools_scm[toml] >= 4
 
-python_requires = >=3.6.*
+python_requires = >=3.6
 
 install_requires =
     attrs


### PR DESCRIPTION
This PR fixes the syntax for setup's python_requires.
Newer version of setuptools (with newer packaging) versions
do not accept star in the Python version  spec.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>