### PR TITLE
Add new attributes for curations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 ==============================
 Changelog
 
+2023-09-28
+    Release 11.0.0
+
+    * Adopt 3.3.2 specification: introducinf the following fields:
+      - ``deployed_resource``
+      - ``is_curated``
+
 2023-09-25
     Release 10.1.0
 

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ In addition, this tool is able to generate attribution notices and
 identify redistributable source code used in your project to help you comply
 with open source licenses conditions.
 
-This version of the AboutCode Toolkit follows the ABOUT specification version 3.3.1 at:
+This version of the AboutCode Toolkit follows the ABOUT specification version 3.3.2 at:
 https://aboutcode-toolkit.readthedocs.io/en/latest/specification.html
 
 

--- a/docs/source/general.rst
+++ b/docs/source/general.rst
@@ -88,6 +88,9 @@ it will copy and store next to the .ABOUT files.
     * - ignored_resources
       - List of paths ignored from the ``about_resource``
       - Optional
+    * - deployed_resource
+      - Path to the resource where the curated resource is deployed
+      - Optional
     * - version
       - Component version
       - Optional
@@ -147,6 +150,9 @@ it will copy and store next to the .ABOUT files.
       - Optional
     * - internal_use_only
       - Yes/No. Is the component internal use only.
+      - Optional
+    * - is_curation
+      - Yes/No. Is the ABOUT file for a curated resource
       - Optional
     * - changelog_file
       - changelog text file name

--- a/docs/source/home.rst
+++ b/docs/source/home.rst
@@ -20,7 +20,7 @@ In addition, this tool is able to generate attribution notices and
 identify redistributable source code used in your project to help you comply
 with open source licenses conditions.
 
-This version of the AboutCode Toolkit follows the ABOUT specification version 3.3.1 at:
+This version of the AboutCode Toolkit follows the ABOUT specification version 3.3.2 at:
 https://aboutcode-toolkit.readthedocs.io/en/latest/specification.html
 
 

--- a/docs/source/specification.rst
+++ b/docs/source/specification.rst
@@ -1,7 +1,7 @@
 .. _specification:
 
 ===============================
-ABOUT File Specification v3.3.1
+ABOUT File Specification v3.3.2
 ===============================
 
 Purpose
@@ -251,6 +251,15 @@ sub-paths under the directory ignored:
                 about_resource: linux-kernel-2.6.23
                 ignored_resources: linux-kernel-2.6.23/Documentation
 
+In this example the ABOUT file is being used to curate resources on the deployed
+side of the code:
+
+        ..  code-block:: none
+
+                about_resource: elasticsearch
+                deployed_resource: elasticsearch-2.3.4.jar
+                is_curated: yes
+
 In this example, the ABOUT file documents the current directory, using a "." period to reference it:
 
         ..  code-block:: none
@@ -272,6 +281,8 @@ Optional Information fields
 -   ignored_resources: A list of paths under the ``about_resource`` path, which are
     not documented in the ABOUT file, and the information in the ABOUT file does not
     apply to these subpaths.
+-   deployed_resource: A single path or a list of paths which point to the resource
+    where the documented resouce is deployed.
 -   version: Component or package version. A component or package usually has a version,
     such as a revision number or hash from a version control system (for a snapshot checked
     out from VCS such as Subversion or Git). If not available, the version should be the date
@@ -359,6 +370,8 @@ Optional Boolean flag fields
 -   modified: Set this flag to yes if the component has been modified. Defaults to no when absent.
 -   internal_use_only: Set this flag to yes if the component is used internal only.
     Defaults to no when absent.
+-   is_curated: Set this flag to yes if the ABOUT file is being used to curate a resource on the
+    deployed code, instead of just plain documenting resources.
 
 Optional Extension fields
 -------------------------

--- a/src/attributecode/__init__.py
+++ b/src/attributecode/__init__.py
@@ -20,9 +20,9 @@ import os
 
 import saneyaml
 
-__version__ = '10.1.0'
+__version__ = '11.0.0'
 
-__about_spec_version__ = '3.3.1'
+__about_spec_version__ = '3.3.2'
 
 __copyright__ = """
 Copyright (c) nexB Inc. All rights reserved. http://dejacode.org

--- a/src/attributecode/model.py
+++ b/src/attributecode/model.py
@@ -551,24 +551,9 @@ class PathField(ListField):
 
 class AboutResourceField(PathField):
     """
-    Special field for about_resource. self.resolved_paths contains a list of
+    Special field for about_resource, which points to the path(s) that the ABOUT
+    file is documenting. self.resolved_paths contains a list of
     the paths resolved relative to the about file path.
-    """
-
-    def __init__(self, *args, ** kwargs):
-        super(AboutResourceField, self).__init__(*args, ** kwargs)
-        self.resolved_paths = []
-
-    def _validate(self, *args, **kwargs):
-        errors = super(AboutResourceField, self)._validate(*args, ** kwargs)
-        return errors
-
-
-class IgnoredResourcesField(PathField):
-    """
-    Special field for ignored_resources. self.ignored_paths contains a list of
-    path patterns (glob patterns) which are not part of the summarization provided
-    by the ABOUT file.
     """
 
     def __init__(self, *args, ** kwargs):
@@ -789,6 +774,7 @@ class About(object):
         self.fields = dict([
             ('about_resource', AboutResourceField(required=True)),
             ('ignored_resources', AboutResourceField()),
+            ('deployed_resource', AboutResourceField()),
             ('name', SingleLineField(required=True)),
             ('version', SingleLineField()),
 
@@ -814,6 +800,8 @@ class About(object):
             ('track_changes', BooleanField()),
             ('modified', BooleanField()),
             ('internal_use_only', BooleanField()),
+
+            ('is_curation', BooleanField()),
 
             ('changelog_file', FileTextField()),
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -478,6 +478,17 @@ class AboutTest(unittest.TestCase):
         result = [f.name for f in a.all_fields() if f.present]
         assert expected == result
 
+    def test_About_loads_deployed_resource_field(self):
+        # fields in this file are not in the standard order
+        test_file = get_test_loc(
+            'test_model/parse/with_deployed_resource.ABOUT')
+        a = model.About(test_file)
+        # assert [] == a.errors
+
+        expected = ['about_resource', 'deployed_resource', 'name', 'is_curated']
+        result = [f.name for f in a.all_fields() if f.present]
+        assert expected == result
+
     def test_About_has_errors_when_about_resource_is_missing(self):
         test_file = get_test_loc('test_gen/parser_tests/.ABOUT')
         a = model.About(test_file)

--- a/tests/testdata/test_model/parse/with_deployed_resource.ABOUT
+++ b/tests/testdata/test_model/parse/with_deployed_resource.ABOUT
@@ -1,0 +1,4 @@
+name: elasticsearch-sidecar
+about_resource: elasticsearch-sidecar
+deployed_resource: elasticsearch-sidecar.jar
+is_curated: yes


### PR DESCRIPTION
Adds two new attributes:
- `deployed_resource`
- `is_curated`

These are used to curate resources in deployed code.

Reference: https://github.com/nexB/scancode.io/issues/834