### PR TITLE
Crash in 'about attrib' when rendering errors occur

### DIFF
--- a/src/attributecode/attrib.py
+++ b/src/attributecode/attrib.py
@@ -329,7 +329,7 @@ def generate_and_save(abouts, is_about_input, license_dict, output_location, sca
     )
 
     if rendering_error:
-        errors.append(rendering_error)
+        errors.extend(rendering_error)
 
     if rendered:
         output_location = add_unc(output_location)


### PR DESCRIPTION
Generating attribution file for a project that has erroneous ABOUT file(s) might lead to crash of the `about` script resulting in a Python backtrace:
~~~
$ about attrib --template <template_file> <base_dir> <attribution_file>
Running aboutcode-toolkit version 11.0.2
Generating attribution...
Traceback (most recent call last):
  File "aboutcode-toolkit/venv/bin/about", line 8, in <module>
    sys.exit(about())
             ^^^^^^^
  File "aboutcode-toolkit/venv/lib/python3.11/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aboutcode-toolkit/venv/lib/python3.11/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "aboutcode-toolkit/venv/lib/python3.11/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aboutcode-toolkit/venv/lib/python3.11/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aboutcode-toolkit/venv/lib/python3.11/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aboutcode-toolkit/src/attributecode/cmd.py", line 571, in attrib
    errors_count = report_errors(
                   ^^^^^^^^^^^^^^
  File "aboutcode-toolkit/src/attributecode/cmd.py", line 863, in report_errors
    log_msgs, severe_errors_count = get_error_messages(errors, verbose)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aboutcode-toolkit/src/attributecode/cmd.py", line 883, in get_error_messages
    severe_errors = filter_errors(errors, WARNING)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aboutcode-toolkit/src/attributecode/util.py", line 635, in filter_errors
    return [e for e in errors if e.severity >= minimum_severity]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aboutcode-toolkit/src/attributecode/util.py", line 635, in <listcomp>
    return [e for e in errors if e.severity >= minimum_severity]
                                 ^^^^^^^^^^
AttributeError: 'list' object has no attribute 'severity'
~~~

Root cause is that the final `errors` list not only contained elements of Error objects but also an additional embedded list of Error objects (e.g. `[Error, Error, Error, [Error, Error, ...] ]`)