### PR TITLE
Replace assert statements with explicit exception handling in non-test files

### DIFF
--- a/src/attributecode/attrib.py
+++ b/src/attributecode/attrib.py
@@ -193,9 +193,15 @@ def generate_sctk_input(abouts, min_license_score, license_dict):
                 for key in lic_key:
                     lic_name.append(license_dict[key][0])
             lic_score = about.license_score.value
-            assert len(lic_key) == len(lic_name)
-            assert len(lic_key) == len(lic_score)
-
+            len_lic_key = len(lic_key)
+            if len_lic_key != len(lic_name):
+                raise ValueError(
+                    f"Mismatch between lengths: lic_key ({len_lic_key}) vs lic_name ({len(lic_name)})"
+                )
+            if len_lic_key != len(lic_score):
+                raise ValueError(
+                    f"Mismatch between lengths: lic_key ({len_lic_key}) vs lic_score ({len(lic_score)})"
+                )
             lic_key_expression = about.license_key_expression.value
             if lic_key_expression:
                 updated_lic_key_expression = []

--- a/src/attributecode/util.py
+++ b/src/attributecode/util.py
@@ -167,7 +167,9 @@ def get_locations(location):
     """
     location = add_unc(location)
     location = get_absolute(location)
-    assert os.path.exists(location)
+    if not os.path.exists(location):
+        raise FileNotFoundError(f"Expected path does not exist: {location}")
+
 
     if os.path.isfile(location):
         yield location
@@ -283,9 +285,10 @@ def get_relative_path(base_loc, full_loc):
     base = norm(base_loc)
     path = norm(full_loc)
 
-    assert path.startswith(base), (
-        "Cannot compute relative path: %(path)r does not start with %(base)r" % locals()
-    )
+    if not path.startswith(base):
+        raise ValueError(
+            f"Cannot compute relative path: {path!r} does not start with {base!r}"
+        )
     base_name = resource_name(base)
     no_dir = base == base_name
     same_loc = base == path


### PR DESCRIPTION
**Summary**

This pull request replaces all assert statements in non-test Python files with explicit exception handling.
The goal is to prevent loss of runtime validation when Python is executed in optimized mode (-O flag), where assert statements are ignored.

**Changes Made**

Replaced assert statements with appropriate ValueError or RuntimeError exceptions.

Added clear and descriptive error messages for better debugging.

Ensured no modifications were made in test-related files or documentation.

**References**

Fixes issue: Replace and rewrite "assert" statements in non-test code (#175)

Discussed in: GitHub search and discussion on assert usage

**Testing**

Verified the changes by running existing unit tests to ensure no regressions.

Confirmed all modified functions raise appropriate exceptions when invalid inputs are provided.